### PR TITLE
Update django_orphaned/management/commands/deleteorphaned.py

### DIFF
--- a/django_orphaned/management/commands/deleteorphaned.py
+++ b/django_orphaned/management/commands/deleteorphaned.py
@@ -5,6 +5,7 @@ from itertools import chain
 from optparse import make_option
 import os
 import shutil
+from django.conf import settings
 
 class Command(BaseCommand):
     help = "Delete all orphaned files"
@@ -40,7 +41,7 @@ class Command(BaseCommand):
                     # we have found a model with FileFields
                     if (len(fields)>0):
                         files = mc.objects.all().values_list(*fields)
-                        needed_files.extend([os.path.join(ORPHANED_APPS_MEDIABASE_DIRS[app]['root'], file) for file in chain.from_iterable(files)])
+                        needed_files.extend([os.path.join(settings.MEDIA_ROOT, file) for file in chain.from_iterable(files)])
 
                 # traverse root folder and store all files and empty directories
                 def should_skip(dir):


### PR DESCRIPTION
Needed files were crafted using the name of their directory (a folder in MEDIA_ROOT) and their file name in database, which is relative to MEDIA_ROOT.
So if you want to check folder/media/images for orphaned files, it will create a list of needed files in the following form : folder/media/images/images/file.ext, which is always wrong unless you upload files directly in MEDIA_ROOT.
