### PR TITLE
Filter out empty files

### DIFF
--- a/django_orphaned/management/commands/deleteorphaned.py
+++ b/django_orphaned/management/commands/deleteorphaned.py
@@ -40,8 +40,8 @@ class Command(BaseCommand):
 
                     # we have found a model with FileFields
                     if (len(fields)>0):
-                        files = filter(None, mc.objects.all().values_list(*fields))
-                        needed_files.extend([os.path.join(settings.MEDIA_ROOT, file) for file in chain.from_iterable(files)])
+                        files = mc.objects.all().values_list(*fields)
+                        needed_files.extend([os.path.join(settings.MEDIA_ROOT, file) for file in filter(None, chain.from_iterable(files))])
 
                 # traverse root folder and store all files and empty directories
                 def should_skip(dir):


### PR DESCRIPTION
This call errors if there are any null file fields, filtering out None's this way seems to resolve it. It should also remove empty string values from needed_files, reducing the amount of duplicates that are just settings.MEDIA_ROOT
