### PR TITLE
Exclude specified files during orphan clean up.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ now add this to your settings.py ('app' is your project name where models.py is 
             'skip': (               # optional iterable of subfolders to preserve, e.g. sorl.thumbnail cache
                 path.join(MEDIABASE_ROOT, 'cache'),
                 path.join(MEDIABASE_ROOT, 'foobar'),
-            )
+            ),
+            'exclude': ('.gitignore') # optional iterable of files to preserve
         }
     }
 

--- a/django_orphaned/management/commands/deleteorphaned.py
+++ b/django_orphaned/management/commands/deleteorphaned.py
@@ -28,6 +28,7 @@ class Command(BaseCommand):
                 total_freed = '0'
                 delete_files = []
                 skip = ORPHANED_APPS_MEDIABASE_DIRS[app].get('skip', ())
+                exclude = ORPHANED_APPS_MEDIABASE_DIRS[app].get('exclude', ())
 
                 for model in ContentType.objects.filter(app_label=app):
                     mc = model.model_class()
@@ -55,7 +56,9 @@ class Command(BaseCommand):
                         continue
                     if (len(files)>0):
                         for basename in files:
-                            all_files.append(os.path.join(root, basename))
+                            if basename not in exclude:
+                                all_files.append(os.path.join(root, basename))
+                                
                     else:
                         if (root != ORPHANED_APPS_MEDIABASE_DIRS[app]['root']) and ((root+'/') != ORPHANED_APPS_MEDIABASE_DIRS[app]['root']):
                             possible_empty_dirs.append(root)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='django-orphaned',
     description='delete all orphaned files from your models',
-    version='0.4',
+    version='0.4.1',
     author='Leonardo Di Lella',
     author_email='leonardo.dilella@mobileapart.com',
     license='MIT',


### PR DESCRIPTION
Similar to the exclude path feature, the app can provide a setting for excluding files that are stored at the 'root' too.
Related issue: https://github.com/ledil/django-orphaned/issues/4
